### PR TITLE
fixed white text on light mode issue

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -6,7 +6,7 @@ class MyDocument extends Document {
     return (
       <Html lang='en' className='theme-compiled'>
         <Head />
-        <body className='antialiased text-lg bg-white dark:bg-gray-900 dark:text-white leading-base'>
+        <body className='antialiased text-lg bg-white text-white dark:bg-gray-900 dark:text-white leading-base'>
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49820575/163831371-c1061acf-a922-4e41-8ad6-e3f95ba8a558.png)
In some cases the text was white in light mode.

It is fixed in this commit.